### PR TITLE
Fix typo in hot osm url

### DIFF
--- a/WMTSCapabilities.xml
+++ b/WMTSCapabilities.xml
@@ -47,7 +47,7 @@
                 <TileMatrixSet>google3857</TileMatrixSet>
             </TileMatrixSetLink>
             <ResourceURL format="image/png"
-                         template="https://tile-a.openstreetmap.fr/{Style}{TileMatrix}/{TileCol}/{TileRow}.png"
+                         template="https://tile-a.openstreetmap.fr/{Style}/{TileMatrix}/{TileCol}/{TileRow}.png"
                          resourceType="tile"/>
             <ResourceURL format="image/png"
                          template="https://tile-b.openstreetmap.fr/{Style}/{TileMatrix}/{TileCol}/{TileRow}.png"


### PR DESCRIPTION
For humanitarian osm the first url contained a typo and was missing a slash between {Style} and {TileMatrix}